### PR TITLE
Fix initial values not set for existing metric on edit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.1 (FUTURE)
+
+### Bugfixes
+
+* [#15](https://github.com/TheDJVG/netbox-more-metrics/issues/15) - Initial choices not set for existing metric on edit.
+
+
 ## 0.2.0 (2023-03-09)
 
 ### Features

--- a/netbox_more_metrics/forms.py
+++ b/netbox_more_metrics/forms.py
@@ -69,3 +69,8 @@ class MetricForm(NetBoxModelForm):
                 self.fields[
                     "metric_value"
                 ].choices = MetricValueChoices.choices_for_contenttype(content_type)
+        elif self.instance.pk:
+            content_type = self.instance.content_type.model_class()
+            self.fields[
+                "metric_value"
+            ].choices = MetricValueChoices.choices_for_contenttype(content_type)


### PR DESCRIPTION
This commit makes sure that when editing an exisiting Metric object the choices are set correctly.

Fixes: #15