### PR TITLE
Allow plugin to run under Netbox 4.X

### DIFF
--- a/netbox_more_metrics/__init__.py
+++ b/netbox_more_metrics/__init__.py
@@ -1,7 +1,11 @@
 from contextlib import suppress
 
 from django.db.utils import ProgrammingError
-from extras.plugins import PluginConfig
+
+try:
+    from netbox.plugins import PluginConfig
+except:
+    from extras.plugins import PluginConfig
 from prometheus_client import REGISTRY
 
 from netbox_more_metrics.utilities import enable_metrics

--- a/netbox_more_metrics/api/views.py
+++ b/netbox_more_metrics/api/views.py
@@ -17,6 +17,7 @@ class MetricCollectionViewSet(NetBoxModelViewSet):
 
 class MetricValueTypeOptionsViewSet(viewsets.ViewSet):
     permission_classes = []
+    queryset = None
 
     def list(self, request):
         content_type = request.query_params.get("object_type")

--- a/netbox_more_metrics/choices.py
+++ b/netbox_more_metrics/choices.py
@@ -4,8 +4,11 @@ from prometheus_client.metrics_core import (
     GaugeMetricFamily,
     InfoMetricFamily,
 )
-from utilities.choices import ChoiceSet
 
+try:
+    from netbox.choices import ChoiceSet
+except:
+    from utilities.choices import ChoiceSet
 
 class MetricTypeChoices(ChoiceSet):
     TYPE_GAUGE = "gauge"

--- a/netbox_more_metrics/navigation.py
+++ b/netbox_more_metrics/navigation.py
@@ -1,5 +1,10 @@
-from extras.plugins import PluginMenuButton, PluginMenuItem
-from utilities.choices import ButtonColorChoices
+
+try:
+    from netbox.plugins import PluginMenuButton, PluginMenuItem
+    from netbox.choices import ButtonColorChoices
+except:
+    from extras.plugins import PluginMenuButton, PluginMenuItem
+    from utilities.choices import ButtonColorChoices
 
 metriccollection_buttons = [
     PluginMenuButton(

--- a/netbox_more_metrics/views.py
+++ b/netbox_more_metrics/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db.models import F, Func, TextField, Value
 from django.http import HttpResponse
 from netbox.views.generic import (
@@ -23,8 +24,10 @@ from netbox_more_metrics.tables import MetricCollectionTable, MetricTable
 
 class MetricCollectionListView(ObjectListView):
     queryset = MetricCollection.objects.all()
-    actions = ("add",)
     table = MetricCollectionTable
+
+    if settings.VERSION.startswith('3.'):
+        actions = ("add",)
 
 
 class MetricCollectionView(ObjectView):
@@ -85,8 +88,9 @@ class MetricListView(ObjectListView):
             output_field=TextField(),
         )
     )
-    actions = ("add",)
     table = MetricTable
+    if settings.VERSION.startswith('3.'):
+        actions = ("add",)
 
 
 class MetricView(ObjectView):


### PR DESCRIPTION
There are only a few minor differences between the plugin API in Netbox 3.X and 4.X. This patch should allow the plugin to run under both Netbox 3 and 4.

