### PR TITLE
Fix incorrect labelnames for Info type metric

### DIFF
--- a/netbox_more_metrics/collectors.py
+++ b/netbox_more_metrics/collectors.py
@@ -256,7 +256,7 @@ class DynamicMetricCollector(Collector):
                 )
 
             if self.metric_family is InfoMetricFamily:
-                metric.add_metric(labels="", value=result)
+                metric.add_metric(labels="", value=labels)
             else:
                 metric.add_metric(labels.values(), value)
 


### PR DESCRIPTION
The wrong source was used for the labels on an Info metric. The result is that the the label name was prepended with `__metric_label_`, an internal reference used for data collection. This commits correct this.

Fixes #30