### PR TITLE
Allow renaming of label names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
   - repo: https://github.com/Riverside-Healthcare/djLint
     rev: v1.34.1
     hooks:
+      - id: djlint-reformat-django
       - id: djlint-django
   - repo: local
     hooks:

--- a/netbox_more_metrics/collectors.py
+++ b/netbox_more_metrics/collectors.py
@@ -96,7 +96,10 @@ class DynamicMetricCollector(Collector):
         self.metric_value_is_method = not self.metric_value == "count"
 
         self.filter = self._metric.filter
-        self.labels = self._metric.metric_labels
+        self.labels = {
+            field: self._metric.label_renames.get(field, field)
+            for field in self._metric.metric_labels
+        }
         self.created = time()
 
         self._internal_labels = (str(self.pk), self.name)
@@ -132,7 +135,7 @@ class DynamicMetricCollector(Collector):
     def test_labels(self):
         # Test the labels make sure they're valid.
         try:
-            self.queryset.values(*self.labels)
+            self.queryset.values(*self.labels.keys())
         except FieldError:
             logger.exception("Metric '%s' (%d) labels are invalid.", self.name, self.pk)
             return False
@@ -159,8 +162,8 @@ class DynamicMetricCollector(Collector):
 
     def get_label_annotations(self):
         annotations = {}
-        for field in self.labels:
-            field_name = f"__metric_label_{field}"
+        for field, label_name in self.labels.items():
+            field_name = f"__metric_label_{label_name}"
             if field.startswith("custom_field_data__"):
                 keys = [Value(key) for key in field.split("__")[1:]]
                 annotations[field_name] = Coalesce(
@@ -187,7 +190,7 @@ class DynamicMetricCollector(Collector):
 
         base_qs = (
             self.get_queryset()
-            .values(*self.labels)
+            .values(*self.labels.keys())
             .annotate(count=Count("*"), **label_annotations)
             .values("count", *values)
         )
@@ -241,13 +244,13 @@ class DynamicMetricCollector(Collector):
             if isinstance(result, dict):
                 labels = {
                     field: result.get(f"__metric_label_{field}")
-                    for field in self.labels
+                    for field in self.labels.values()
                 }
                 value = result.pop(self.metric_value)
             else:
                 labels = {
                     field: getattr(result, f"__metric_label_{field}")
-                    for field in self.labels
+                    for field in self.labels.values()
                 }
                 value = (
                     getattr(result, self.metric_value)

--- a/netbox_more_metrics/forms.py
+++ b/netbox_more_metrics/forms.py
@@ -39,7 +39,10 @@ class MetricForm(NetBoxModelForm):
     label_renames = JSONField(
         label="Label renaming",
         help_text="Rename label names to make them clearer. "
-        "For example, 'device__manufacturer_slug' to 'manufacturer'.",
+        "For example, 'device__manufacturer_slug' to 'manufacturer':"
+        """<pre>{
+    "device__manufacturer_slug": "manufacturer"
+}</pre>""",
         required=False,
     )
 

--- a/netbox_more_metrics/forms.py
+++ b/netbox_more_metrics/forms.py
@@ -4,6 +4,7 @@ from netbox.forms import NetBoxModelForm
 from utilities.forms.fields import (
     ContentTypeChoiceField,
     DynamicModelMultipleChoiceField,
+    JSONField,
 )
 from utilities.forms.rendering import FieldSet
 
@@ -35,7 +36,7 @@ class MetricForm(NetBoxModelForm):
         help_text="Select the value used for the metric. This might ignore aggregation done by labels.",
     )
 
-    label_renames = forms.JSONField(
+    label_renames = JSONField(
         label="Label renaming",
         help_text="Rename label names to make them clearer. "
         "For example, 'device__manufacturer_slug' to 'manufacturer'.",
@@ -71,6 +72,9 @@ class MetricForm(NetBoxModelForm):
             "content_type",
             "collections",
         )
+        field_classes = {
+            "filter": JSONField,
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/netbox_more_metrics/forms.py
+++ b/netbox_more_metrics/forms.py
@@ -35,12 +35,20 @@ class MetricForm(NetBoxModelForm):
         help_text="Select the value used for the metric. This might ignore aggregation done by labels.",
     )
 
+    label_renames = forms.JSONField(
+        label="Label renaming",
+        help_text="Rename label names to make them clearer. "
+        "For example, 'device__manufacturer_slug' to 'manufacturer'.",
+        required=False,
+    )
+
     fieldsets = (
         FieldSet("name", "metric_description", "enabled", "tags"),
         FieldSet("content_type", "filter", name="Metric source"),
         FieldSet(
             "metric_name",
             "metric_labels",
+            "label_renames",
             "metric_type",
             "metric_value",
             name="Metric configuration",
@@ -58,6 +66,7 @@ class MetricForm(NetBoxModelForm):
             "metric_labels",
             "metric_type",
             "metric_value",
+            "label_renames",
             "filter",
             "content_type",
             "collections",

--- a/netbox_more_metrics/migrations/0004_metric_label_renames.py
+++ b/netbox_more_metrics/migrations/0004_metric_label_renames.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+import netbox_more_metrics.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("netbox_more_metrics", "0003_alter_metric_content_type"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="metric",
+            name="label_renames",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                validators=[netbox_more_metrics.validators.validate_label_renames],
+            ),
+        ),
+    ]

--- a/netbox_more_metrics/models.py
+++ b/netbox_more_metrics/models.py
@@ -113,7 +113,10 @@ class Metric(NetBoxModel, ObjectAbsoluteUrlMixin):
                 if label in self.label_renames.values():
                     # If it is it's possible that the label is being renamed to something else, if not, trigger a
                     # ValidationError
-                    if label == self.label_renames.get(label):
+                    if (
+                        label not in self.label_renames
+                        or label == self.label_renames.get(label)
+                    ):
                         raise ValidationError(
                             {
                                 "label_renames": f"Label '{label}' is being shadowed by a label rename."

--- a/netbox_more_metrics/models.py
+++ b/netbox_more_metrics/models.py
@@ -6,7 +6,11 @@ from django.utils.translation import gettext as _
 from netbox.models import NetBoxModel
 
 from netbox_more_metrics.choices import MetricTypeChoices
-from netbox_more_metrics.validators import validate_label_name, validate_metric_name
+from netbox_more_metrics.validators import (
+    validate_label_name,
+    validate_label_renames,
+    validate_metric_name,
+)
 
 
 class ObjectAbsoluteUrlMixin:
@@ -58,6 +62,13 @@ class Metric(NetBoxModel, ObjectAbsoluteUrlMixin):
     filter = models.JSONField(
         null=False, default=dict, blank=True, help_text=_("QuerySet filter")
     )
+    label_renames = models.JSONField(
+        null=False,
+        default=dict,
+        blank=True,
+        help_text=_("Label renaming"),
+        validators=[validate_label_renames],
+    )
     collections = models.ManyToManyField(to=MetricCollection, related_name="metrics")
 
     def __str__(self):
@@ -85,6 +96,29 @@ class Metric(NetBoxModel, ObjectAbsoluteUrlMixin):
                 raise ValidationError({"filter": f"Filter invalid: {e}"})
         else:
             self.filter = {}
+
+        if self.label_renames:
+            # Make sure all renamed labels exists as labels
+            for label in self.label_renames:
+                if label not in self.metric_labels:
+                    raise ValidationError(
+                        {
+                            "label_renames": f"Label '{label}' is not in the metric labels."
+                        }
+                    )
+
+            # Make sure there's no duplicate label names
+            for label in self.metric_labels:
+                # First check if the label is in the label_renames:
+                if label in self.label_renames.values():
+                    # If it is it's possible that the label is being renamed to something else, if not, trigger a
+                    # ValidationError
+                    if label == self.label_renames.get(label):
+                        raise ValidationError(
+                            {
+                                "label_renames": f"Label '{label}' is being shadowed by a label rename."
+                            }
+                        )
 
     @property
     def metric_family(self):

--- a/netbox_more_metrics/templates/netbox_more_metrics/metric.html
+++ b/netbox_more_metrics/templates/netbox_more_metrics/metric.html
@@ -1,18 +1,16 @@
 {% extends "generic/object.html" %}
-
 {% block extra_controls %}
-<a href="{% url 'plugins:netbox_more_metrics:metric_metrics' pk=object.pk %}" class="btn btn-info" role="button">
-    <i class="mdi mdi-export" aria-hidden="true"></i>&nbsp;Export Metrics
-</a>
+    <a href="{% url 'plugins:netbox_more_metrics:metric_metrics' pk=object.pk %}"
+       class="btn btn-info"
+       role="button">
+        <i class="mdi mdi-export" aria-hidden="true"></i>&nbsp;Export Metrics
+    </a>
 {% endblock extra_controls %}
-
 {% block content %}
-<div class="row">
-    <div class="col col-md-6">
-        <div class="card">
-            <h5 class="card-header">
-                Metric
-            </h5>
+    <div class="row">
+        <div class="col col-md-6">
+            <div class="card">
+                <h5 class="card-header">Metric</h5>
                 <table class="table table-hover attr-table">
                     <tr>
                         <th scope="row">Name</th>
@@ -26,19 +24,15 @@
                         <th scope="row">Enabled</th>
                         <td>{% checkmark object.enabled %}</td>
                     </tr>
-
                 </table>
+            </div>
+            {% include "inc/panel_table.html" with table=collections_table heading="Exported in collections" %}
+            {% include "inc/panels/tags.html" %}
+            {% include "inc/panels/custom_fields.html" %}
         </div>
-
-        {% include "inc/panel_table.html" with table=collections_table heading="Exported in collections" %}
-        {% include "inc/panels/tags.html" %}
-        {% include "inc/panels/custom_fields.html" %}
-    </div>
-    <div class="col col-md-6">
-        <div class="card">
-            <h5 class="card-header">
-                Metric Configuration
-            </h5>
+        <div class="col col-md-6">
+            <div class="card">
+                <h5 class="card-header">Metric Configuration</h5>
                 <table class="table table-hover attr-table">
                     <tr>
                         <th scope="row">Name</th>
@@ -61,33 +55,52 @@
                         <td>{{ object.content_type }}</td>
                     </tr>
                 </table>
-        </div>
-
-        <div class="card">
-            <h5 class="card-header">
-                Filter
-            </h5>
-            <div class="card-body">
-                {% if object.filter %}
-                <pre>{{ object.filter | json }}</pre>
+            </div>
+            <div class="card">
+                <h5 class="card-header">Label renaming</h5>
+                {% if object.label_renames %}
+                    <table class="table table-hover">
+                        <thead>
+                            <tr>
+                                <th>From</th>
+                                <th>To</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for from, to in object.label_renames.items %}
+                                <tr>
+                                    <td>{{ from }}</td>
+                                    <td>{{ to }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
                 {% else %}
-                <span class="text-muted">None</span>
+                    <div class="card-body">
+                        <span class="text-muted">No labels renamed</span>
+                    </div>
                 {% endif %}
             </div>
-        </div>
-    </div>
-</div>
-<div class="row">
-    <div class="col col-md-12">
-        <div class="card">
-            <h5 class="card-header">
-                Generated Metrics
-            </h5>
-            <div class="card-body">
-                <pre>{{ metrics }}</pre>
+            <div class="card">
+                <h5 class="card-header">Filter</h5>
+                <div class="card-body">
+                    {% if object.filter %}
+                        <pre>{{ object.filter | json }}</pre>
+                    {% else %}
+                        <span class="text-muted">None</span>
+                    {% endif %}
+                </div>
             </div>
         </div>
     </div>
-</div>
+    <div class="row">
+        <div class="col col-md-12">
+            <div class="card">
+                <h5 class="card-header">Generated Metrics</h5>
+                <div class="card-body">
+                    <pre>{{ metrics }}</pre>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock content %}
-

--- a/netbox_more_metrics/validators.py
+++ b/netbox_more_metrics/validators.py
@@ -1,4 +1,4 @@
-from django.core.validators import RegexValidator
+from django.core.validators import RegexValidator, ValidationError
 from django.utils.regex_helper import _lazy_re_compile
 from django.utils.translation import gettext_lazy as _
 
@@ -15,3 +15,40 @@ validate_label_name = RegexValidator(
     _("Enter a valid “label_name” consisting of letters, numbers or underscores."),
     "invalid",
 )
+
+
+def validate_label_renames(value):
+    """
+    Validator to ensure that the JSONField only contains key-value pairs where both keys and values are strings.
+    Nested structures are not allowed.
+    """
+    if not isinstance(value, dict):
+        raise ValidationError(
+            _("Invalid data type: %(value)s. Expected a dictionary."),
+            params={"value": value},
+        )
+
+    seen_label_names = set()
+    for key, val in value.items():
+        if not isinstance(key, str):
+            raise ValidationError(
+                _("Invalid key type: %(key)s. Expected a string."),
+                params={"key": key},
+            )
+        if not isinstance(val, str):
+            raise ValidationError(
+                _("Invalid value type for key '%(key)s': %(val)s. Expected a string."),
+                params={"key": key, "val": val},
+            )
+
+        if val in seen_label_names:
+            raise ValidationError(
+                _("Duplicate label name: %(val)s."),
+                params={"val": val},
+            )
+
+        # Add the label name to the set of seen label names
+        seen_label_names.add(val)
+
+        # Check if the value is a valid label name
+        validate_label_name(val)


### PR DESCRIPTION
This PR introduces a way of renaming labels. You will set a JSON
with the key being the original label and the value being the new
labelname.

Validation should catch most cases when trying to rename existing keys
and takes into account that original labels might be renamed too.

Example json:
```json
{"name": "random_name", "custom_field_data__group": "custom_group"}
```

Fixes https://github.com/TheDJVG/netbox-more-metrics/issues/9