### PR TITLE
Fix incorrect mixin on model order

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Create custom metrics and export information from NetBox into your timeseries da
 | NetBox Version | Plugin Version |
 |----------------|----------------|
 | 3.4 <= 3.7     | 0.1.X, 0.2.X   |
-| 4.0            | 0.3.X          |
+| 4.0 <= 4.2     | 0.3.X          |
 
 ## Installing
 

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -1,7 +1,7 @@
-FROM netboxcommunity/netbox:v4.0
+FROM netboxcommunity/netbox:v4.2
 
 # Install poetry
-RUN pip install --upgrade pip && pip install poetry
+RUN /usr/local/bin/uv pip install --upgrade pip && /usr/local/bin/uv pip install poetry
 
 # Install plugin
 RUN mkdir -p /source

--- a/netbox_more_metrics/models.py
+++ b/netbox_more_metrics/models.py
@@ -19,7 +19,7 @@ class ObjectAbsoluteUrlMixin:
         return reverse(path, args=[self.pk])
 
 
-class MetricCollection(NetBoxModel, ObjectAbsoluteUrlMixin):
+class MetricCollection(ObjectAbsoluteUrlMixin, NetBoxModel):
     """
     Model that represents a CollectorRegistry.
     You can connect Metric instances to this to export only these specific metrics.
@@ -36,7 +36,7 @@ class MetricCollection(NetBoxModel, ObjectAbsoluteUrlMixin):
         return self.name
 
 
-class Metric(NetBoxModel, ObjectAbsoluteUrlMixin):
+class Metric(ObjectAbsoluteUrlMixin, NetBoxModel):
     """
     Represents a single Metric to be exported.
     """


### PR DESCRIPTION
It was noted in #37 that the the new `get_absolute_url` from NetBoxModel is taking precendence (introduced in 4.2).

This commit fixes that order. In the next major release (meant for 4.2 and higher) I will remove the mixin completly and use the standardized NetBox method.

Fixes: #37