### PR TITLE
fix #43 label renaming not working

### DIFF
--- a/netbox_more_metrics/collectors.py
+++ b/netbox_more_metrics/collectors.py
@@ -234,7 +234,7 @@ class DynamicMetricCollector(Collector):
 
         # Create the metric
         metric: GaugeMetricFamily | CounterMetricFamily | InfoMetricFamily = (
-            self.metric_family(self.name, self.description, labels=self.labels)
+            self.metric_family(self.name, self.description, labels=list(self.labels.values()))
         )
 
         # Get the data for the metric.


### PR DESCRIPTION
Fix issue #43 

data for the tests:
- metric labels: site__slug,tenant__name
- label renaming:
 ```
{
    "tenant__name": "tenant"
}
```

Original Code
```
        # Create the metric
        metric: GaugeMetricFamily | CounterMetricFamily | InfoMetricFamily = (
            self.metric_family(self.name, self.description, labels=self.labels)
        )
        print('labels', self.labels)
        # result labels {'site__slug': 'site__slug', 'tenant__name': 'tenant'}
```

The self. labels should be ["site__slug", "tenant"] 

Code change
```
self.metric_family(self.name, self.description, labels=list(self.labels.values()))
```